### PR TITLE
Convert messages window to pad

### DIFF
--- a/message_handlers/rx_handler.py
+++ b/message_handlers/rx_handler.py
@@ -70,7 +70,7 @@ def on_receive(packet, interface):
             if(refresh_channels):
                 draw_channel_list()
             if(refresh_messages):
-                draw_messages_window()
+                draw_messages_window(True)
 
             save_message_to_db(globals.channel_list[channel_number], message_from_id, message_string)
 

--- a/message_handlers/tx_handler.py
+++ b/message_handlers/tx_handler.py
@@ -109,7 +109,7 @@ def on_response_traceroute(packet):
     if(refresh_channels):
         draw_channel_list()
     if(refresh_messages):
-        draw_messages_window()
+        draw_messages_window(True)
     save_message_to_db(globals.channel_list[channel_number], packet['from'], msg_str)
 
 def send_message(message, destination=BROADCAST_NUM, channel=0):

--- a/ui/curses_ui.py
+++ b/ui/curses_ui.py
@@ -93,11 +93,14 @@ def draw_messages_window():
     if channel in globals.all_messages:
         messages = globals.all_messages[channel]
 
+        msg_lines = 0
+
         # Display messages starting from the calculated start index
         row = 0
         for (prefix, message) in messages:
             full_message = f"{prefix}{message}"
             wrapped_lines = textwrap.wrap(full_message, messages_box.getmaxyx()[1] - 2)
+            msg_lines += len(wrapped_lines)
 
             for line in wrapped_lines:
                 # Highlight the row if it's the selected message
@@ -133,7 +136,6 @@ def draw_node_list():
 
     nodes_win.box()
     nodes_win.refresh()
-
 
 def select_channels(direction):
     channel_list_length = len(globals.channel_list)

--- a/ui/curses_ui.py
+++ b/ui/curses_ui.py
@@ -84,7 +84,6 @@ def draw_channel_list():
     channel_win.box()
     channel_win.refresh()
 
-
 def draw_messages_window():
     """Update the messages window based on the selected channel and scroll position."""
     messages_pad.clear()
@@ -93,10 +92,6 @@ def draw_messages_window():
 
     if channel in globals.all_messages:
         messages = globals.all_messages[channel]
-
-        # Adjust for packetlog height if log is visible
-        if globals.display_log:
-            packetlog_height = packetlog_win.getmaxyx()[0]
 
         # Display messages starting from the calculated start index
         row = 0
@@ -113,14 +108,18 @@ def draw_messages_window():
                 messages_pad.addstr(row, 1, line, color)
                 row += 1
 
-    messages_pad.refresh(0, 0, 
+    messages_box.box()
+    messages_box.refresh()
+
+    # Adjust for packetlog height if log is visible
+    packetlog_height = packetlog_win.getmaxyx()[0] if globals.display_log else 0
+    messages_pad.refresh(globals.selected_message, 0, 
                          messages_box.getbegyx()[0] + 1, messages_box.getbegyx()[1] + 1, 
-                         messages_box.getbegyx()[0] + messages_box.getmaxyx()[0] - 2, messages_box.getbegyx()[1] + messages_box.getmaxyx()[1] - 2)
+                         messages_box.getbegyx()[0] + messages_box.getmaxyx()[0] - 2 - packetlog_height, messages_box.getbegyx()[1] + messages_box.getmaxyx()[1] - 2)
 
     draw_packetlog_win()
 
 def draw_node_list():
-
     nodes_win.clear()                 
     win_height = nodes_win.getmaxyx()[0]
     start_index = max(0, globals.selected_node - (win_height - 3))  # Calculate starting index based on selected node and window height
@@ -151,22 +150,18 @@ def select_channels(direction):
     draw_messages_window()
 
 def select_messages(direction):
-    # messages_length = len(globals.all_messages[globals.channel_list[globals.selected_channel]])
-
     globals.selected_message += direction
+    globals.selected_message = max(globals.selected_message, 0)
 
     # if globals.selected_message < 0:
     #     globals.selected_message = messages_length - 1
     # elif globals.selected_message >= messages_length:
     #     globals.selected_message = 0
 
-    # draw_messages_window()
-
-    # messages_win.refresh(globals.selected_message, 0, 4, channel_width + 1, 3 + height - 8, channel_width + messages_width - 2)
+    packetlog_height = packetlog_win.getmaxyx()[0] if globals.display_log else 0
     messages_pad.refresh(globals.selected_message, 0, 
                          messages_box.getbegyx()[0] + 1, messages_box.getbegyx()[1] + 1, 
-                         messages_box.getbegyx()[0] + messages_box.getmaxyx()[0] - 2, messages_box.getbegyx()[1] + messages_box.getmaxyx()[1] - 2)
-
+                         messages_box.getbegyx()[0] + messages_box.getmaxyx()[0] - 2 - packetlog_height, messages_box.getbegyx()[1] + messages_box.getmaxyx()[1] - 2)
 
 
 def select_nodes(direction):

--- a/ui/curses_ui.py
+++ b/ui/curses_ui.py
@@ -244,10 +244,6 @@ def main_ui(stdscr):
 
     draw_centered_text_field(function_win, f"↑→↓← = Select    ENTER = Send    ` = Settings    ^P = Packet Log    ESC = Quit")
 
-    draw_channel_list()
-    draw_node_list()
-    draw_messages_window(True)
-
     # Draw boxes around windows
     channel_win.box()
     entry_win.box()
@@ -266,6 +262,10 @@ def main_ui(stdscr):
 
     entry_win.keypad(True)
     curses.curs_set(1)
+
+    draw_channel_list()
+    draw_node_list()
+    draw_messages_window(True)
 
     while True:
         draw_text_field(entry_win, f"Input: {input_text}")

--- a/ui/curses_ui.py
+++ b/ui/curses_ui.py
@@ -154,10 +154,7 @@ def select_messages(direction):
     globals.selected_message += direction
 
     msg_line_count = messages_pad.getmaxyx()[0]
-    if globals.selected_message < 0:
-        globals.selected_message = max(msg_line_count - get_msg_window_lines(), 0)
-    elif globals.selected_message > (msg_line_count - get_msg_window_lines()):
-        globals.selected_message = 0
+    globals.selected_message = max(0, min(globals.selected_message, msg_line_count - get_msg_window_lines()))
 
     messages_pad.refresh(globals.selected_message, 0,
                          messages_box.getbegyx()[0] + 1, messages_box.getbegyx()[1] + 1,

--- a/ui/curses_ui.py
+++ b/ui/curses_ui.py
@@ -84,7 +84,7 @@ def draw_channel_list():
     channel_win.box()
     channel_win.refresh()
 
-def draw_messages_window():
+def draw_messages_window(scroll_to_bottom = False):
     """Update the messages window based on the selected channel and scroll position."""
     messages_pad.clear()
 
@@ -93,20 +93,16 @@ def draw_messages_window():
     if channel in globals.all_messages:
         messages = globals.all_messages[channel]
 
-        msg_lines = 0
+        msg_line_count = 0
 
-        # Display messages starting from the calculated start index
         row = 0
         for (prefix, message) in messages:
             full_message = f"{prefix}{message}"
             wrapped_lines = textwrap.wrap(full_message, messages_box.getmaxyx()[1] - 2)
-            msg_lines += len(wrapped_lines)
+            msg_line_count += len(wrapped_lines)
+            messages_pad.resize(msg_line_count, messages_box.getmaxyx()[1])
 
             for line in wrapped_lines:
-                # Highlight the row if it's the selected message
-                # if index == globals.selected_message and globals.current_window == 1:
-                    # color = curses.color_pair(3)  # Highlighted row color
-                # else:
                 color = curses.color_pair(1) if prefix.startswith(globals.sent_message_prefix) else curses.color_pair(2)
                 messages_pad.addstr(row, 1, line, color)
                 row += 1
@@ -114,11 +110,16 @@ def draw_messages_window():
     messages_box.box()
     messages_box.refresh()
 
+    if(scroll_to_bottom):
+        globals.selected_message = max(msg_line_count - get_msg_window_lines(), 0)
+    else:
+        globals.selected_message = max(min(globals.selected_message, msg_line_count - get_msg_window_lines()), 0)
+
     # Adjust for packetlog height if log is visible
     packetlog_height = packetlog_win.getmaxyx()[0] if globals.display_log else 0
-    messages_pad.refresh(globals.selected_message, 0, 
-                         messages_box.getbegyx()[0] + 1, messages_box.getbegyx()[1] + 1, 
-                         messages_box.getbegyx()[0] + messages_box.getmaxyx()[0] - 2 - packetlog_height, messages_box.getbegyx()[1] + messages_box.getmaxyx()[1] - 2)
+    messages_pad.refresh(globals.selected_message, 0,
+                         messages_box.getbegyx()[0] + 1, messages_box.getbegyx()[1] + 1,
+                         messages_box.getbegyx()[0] + get_msg_window_lines(), messages_box.getbegyx()[1] + messages_box.getmaxyx()[1] - 2)
 
     draw_packetlog_win()
 
@@ -146,25 +147,21 @@ def select_channels(direction):
     elif globals.selected_channel >= channel_list_length:
         globals.selected_channel = 0
 
-    globals.selected_message = len(globals.all_messages[globals.channel_list[globals.selected_channel]]) - 1
-
     draw_channel_list()
-    draw_messages_window()
+    draw_messages_window(True)
 
 def select_messages(direction):
     globals.selected_message += direction
-    globals.selected_message = max(globals.selected_message, 0)
 
-    # if globals.selected_message < 0:
-    #     globals.selected_message = messages_length - 1
-    # elif globals.selected_message >= messages_length:
-    #     globals.selected_message = 0
+    msg_line_count = messages_pad.getmaxyx()[0]
+    if globals.selected_message < 0:
+        globals.selected_message = max(msg_line_count - get_msg_window_lines(), 0)
+    elif globals.selected_message > (msg_line_count - get_msg_window_lines()):
+        globals.selected_message = 0
 
-    packetlog_height = packetlog_win.getmaxyx()[0] if globals.display_log else 0
-    messages_pad.refresh(globals.selected_message, 0, 
-                         messages_box.getbegyx()[0] + 1, messages_box.getbegyx()[1] + 1, 
-                         messages_box.getbegyx()[0] + messages_box.getmaxyx()[0] - 2 - packetlog_height, messages_box.getbegyx()[1] + messages_box.getmaxyx()[1] - 2)
-
+    messages_pad.refresh(globals.selected_message, 0,
+                         messages_box.getbegyx()[0] + 1, messages_box.getbegyx()[1] + 1,
+                         messages_box.getbegyx()[0] + get_msg_window_lines(), messages_box.getbegyx()[1] + messages_box.getmaxyx()[1] - 2)
 
 def select_nodes(direction):
     node_list_length = len(globals.node_list)
@@ -239,7 +236,8 @@ def main_ui(stdscr):
     channel_win = curses.newwin(height - 6, channel_width, 3, 0)
     messages_box = curses.newwin(height - 6, messages_width, 3, channel_width)
 
-    messages_pad = curses.newpad(1000, 1000)
+    # Will be resized to what we need when drawn
+    messages_pad = curses.newpad(1, 1)
     packetlog_win = curses.newwin(int(height / 3), messages_width, height - int(height / 3) - 3, channel_width)
     nodes_win = curses.newwin(height - 6, nodes_width, 3, channel_width + messages_width)
     function_win = curses.newwin(3, width, height - 3, 0)
@@ -248,7 +246,7 @@ def main_ui(stdscr):
 
     draw_channel_list()
     draw_node_list()
-    draw_messages_window()
+    draw_messages_window(True)
 
     # Draw boxes around windows
     channel_win.box()
@@ -281,7 +279,6 @@ def main_ui(stdscr):
         if char == curses.KEY_UP:
             if globals.current_window == 0:
                 select_channels(-1)
-                # globals.selected_message = len(globals.all_messages[globals.channel_list[globals.selected_channel]]) - 1
             elif globals.current_window == 1:
                 select_messages(-1)
             elif globals.current_window == 2:
@@ -290,7 +287,6 @@ def main_ui(stdscr):
         elif char == curses.KEY_DOWN:
             if globals.current_window == 0:
                 select_channels(1)
-                # globals.selected_message = len(globals.all_messages[globals.channel_list[globals.selected_channel]]) - 1
             elif globals.current_window == 1:
                 select_messages(1)
             elif globals.current_window == 2:
@@ -333,12 +329,12 @@ def main_ui(stdscr):
 
                 draw_node_list()
                 draw_channel_list()
-                draw_messages_window()
+                draw_messages_window(True)
 
             else:
                 # Enter key pressed, send user input as message
                 send_message(input_text, channel=globals.selected_channel)
-                draw_messages_window()
+                draw_messages_window(True)
 
                 # Clear entry window and reset input text
                 input_text = ""
@@ -363,14 +359,18 @@ def main_ui(stdscr):
             # Display packet log
             if globals.display_log is False:
                 globals.display_log = True
-                draw_messages_window()
+                draw_messages_window(True)
             else:
                 globals.display_log = False
                 packetlog_win.clear()
-                draw_messages_window()
+                draw_messages_window(True)
         else:
             # Append typed character to input text
             if(isinstance(char, str)):
                 input_text += char
             else:
                 input_text += chr(char)
+
+def get_msg_window_lines():
+    packetlog_height = packetlog_win.getmaxyx()[0] if globals.display_log else 0
+    return messages_box.getmaxyx()[0] - 2 - packetlog_height


### PR DESCRIPTION
Very much work in progress - @pdxlocations I was wondering if you'd be able to test this on the SBC you've got to see if this approach is feasible. I'm just making an arbitrarily large pad area and I dunno the performance implications of that. Scrolling the messages window this way however doesn't require fully re-drawing the whole thing so I'm wondering if it might actually perform better? I was thinking a good test could be to manually/script add a couple hundred messages into the DB, at least some of which wrap (but not so many messages that it would reach 1,000 lines since I set the pad width/height to 1,000 and haven't implemented any protection against overflow yet) and view that conversation in the client on the target HW. 

I'm only able to test on a modern intel desktop and an m2 macbook, so hard for me to tell if this helps or hurts or is even a viable strategy for the FemtoFox/LuckFox HW target. Scrolling the messages window no longer appears to refresh the screen though, which is cool - it feels smoother that way.

This approach would fix #35  

