### PR TITLE
Make forward slash possible to type

### DIFF
--- a/ui/curses_ui.py
+++ b/ui/curses_ui.py
@@ -265,7 +265,7 @@ def main_ui(stdscr):
     nodes_win = curses.newwin(height - 6, nodes_width, 3, channel_width + messages_width)
     function_win = curses.newwin(3, width, height - 3, 0)
 
-    draw_centered_text_field(function_win, f"↑→↓← = Select    ENTER = Send    ` = Settings    / = Toggle Log    ESC = Quit")
+    draw_centered_text_field(function_win, f"↑→↓← = Select    ENTER = Send    ` = Settings    ^P = Packet Log    ESC = Quit")
 
     # Enable scrolling for messages and nodes windows
     messages_win.scrollok(True)
@@ -385,7 +385,7 @@ def main_ui(stdscr):
             settings_menu(stdscr, globals.interface)
             curses.curs_set(1)
         
-        elif char == "/":
+        elif char == chr(16):
             # Display packet log
             if globals.display_log is False:
                 globals.display_log = True


### PR DESCRIPTION
Packet log is now Ctrl + P

Fixes #42 