### PR TITLE
Don't allow sending empty string

### DIFF
--- a/ui/curses_ui.py
+++ b/ui/curses_ui.py
@@ -475,7 +475,7 @@ def main_ui(stdscr):
                 draw_channel_list()
                 draw_messages_window(True)
 
-            else:
+            elif len(input_text) > 0:
                 # Enter key pressed, send user input as message
                 send_message(input_text, channel=globals.selected_channel)
                 draw_messages_window(True)


### PR DESCRIPTION
I keep accidentally sending nothing while playing around with this. Require at least one character of any text before we'll send a message. This will still allow sending eg a single space character, just not literally nothing.