### PR TITLE
Reduce redraws in settings

### DIFF
--- a/globals.py
+++ b/globals.py
@@ -44,5 +44,5 @@ COLOR_CONFIG = {
     "log_header": ("blue", "black"),
     "log": ("green", "black"),
     "settings_sensitive": ("red", "black"),
-    "settings_okay": ("green", "black")
+    "settings_save": ("green", "black")
 }

--- a/settings.py
+++ b/settings.py
@@ -49,7 +49,7 @@ def display_menu(current_menu, menu_path, selected_index, show_save_option):
     if show_save_option:
         save_option = "Save Changes"
         save_position = height - 2
-        menu_win.addstr(save_position, (width - len(save_option)) // 2, save_option, get_color("settings_okay", reverse = (selected_index == len(current_menu))))
+        menu_win.addstr(save_position, (width - len(save_option)) // 2, save_option, get_color("settings_save", reverse = (selected_index == len(current_menu))))
 
     menu_win.refresh()
 
@@ -60,14 +60,14 @@ def move_highlight(old_idx, new_idx, max_idx, show_save, menu_win):
     width = 60
     save_option = "Save Changes"
     if show_save and old_idx == max_idx: # special case un-highlight "Save" option
-        menu_win.chgat(max_idx + 4, (width - len(save_option)) // 2, len(save_option), curses.color_pair(2))
+        menu_win.chgat(max_idx + 4, (width - len(save_option)) // 2, len(save_option), get_color("settings_save"))
     else:
-        menu_win.chgat(old_idx + 3, 4, width - 8, curses.color_pair(1))
+        menu_win.chgat(old_idx + 3, 4, width - 8, get_color("default"))
 
     if show_save and new_idx == max_idx: # special case highlight "Save" option
-        menu_win.chgat(max_idx + 4, (width - len(save_option)) // 2, len(save_option), curses.color_pair(2) | curses.A_REVERSE)
+        menu_win.chgat(max_idx + 4, (width - len(save_option)) // 2, len(save_option), get_color("settings_save", reverse = True))
     else:
-       menu_win.chgat(new_idx + 3, 4, width - 8, curses.color_pair(1) | curses.A_REVERSE )
+       menu_win.chgat(new_idx + 3, 4, width - 8, get_color("default", reverse = True))
 
     menu_win.refresh()
 

--- a/ui/curses_ui.py
+++ b/ui/curses_ui.py
@@ -475,7 +475,7 @@ def main_ui(stdscr):
                 draw_channel_list()
                 draw_messages_window(True)
 
-            else:
+            elif len(input_text) > 0:
                 # Enter key pressed, send user input as message
                 send_message(input_text, channel=globals.selected_channel)
                 draw_messages_window(True)


### PR DESCRIPTION
Give settings the ol' russ "chgat()" treatment so we don't refresh the screen when scrolling through a menu 