### PR TITLE
Enable scrolling settings options

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -14,7 +14,7 @@ save_option = "Save Changes"
 sensitive_settings = ["Reboot", "Reset Node DB", "Shutdown", "Factory Reset"]
 
 def display_menu(current_menu, menu_path, selected_index, show_save_option):
-    global menu_win
+    global menu_win, menu_pad
 
     # Calculate the dynamic height based on the number of menu items
     num_items = len(current_menu) + (1 if show_save_option else 0)  # Add 1 for the "Save Changes" option if applicable
@@ -29,6 +29,8 @@ def display_menu(current_menu, menu_path, selected_index, show_save_option):
     menu_win.attrset(get_color("window_frame"))
     menu_win.border()
     menu_win.keypad(True)
+
+    menu_pad = curses.newpad(len(current_menu), width - 8)
 
     # Display the current menu path as a header
     header = " > ".join(word.title() for word in menu_path)
@@ -46,7 +48,7 @@ def display_menu(current_menu, menu_path, selected_index, show_save_option):
         try:
             # Use red color for "Reboot" or "Shutdown"
             color = get_color("settings_sensitive" if option in sensitive_settings else "settings_default", reverse = (idx == selected_index))
-            menu_win.addstr(idx + 3, 4, f"{display_option:<{width // 2 - 2}} {display_value}".ljust(width - 8), color)
+            menu_pad.addstr(idx, 0, f"{display_option:<{width // 2 - 2}} {display_value}".ljust(menu_pad.getmaxyx()[0]).ljust(width - 8), color)
         except curses.error:
             pass
 
@@ -56,6 +58,9 @@ def display_menu(current_menu, menu_path, selected_index, show_save_option):
         menu_win.addstr(save_position, (width - len(save_option)) // 2, save_option, get_color("settings_save", reverse = (selected_index == len(current_menu))))
 
     menu_win.refresh()
+    menu_pad.refresh(0, 0,
+                     menu_win.getbegyx()[0] + 3, menu_win.getbegyx()[1] + 4,
+                     menu_win.getbegyx()[0] + 3 + menu_win.getmaxyx()[0] - 5 - (2 if show_save_option else 0), menu_win.getbegyx()[1] + menu_win.getmaxyx()[1] - 8)
 
 def move_highlight(old_idx, new_idx, options, show_save_option, menu_win):
 
@@ -65,16 +70,21 @@ def move_highlight(old_idx, new_idx, options, show_save_option, menu_win):
     max_index = len(options) + (1 if show_save_option else 0) - 1
 
     if show_save_option and old_idx == max_index: # special case un-highlight "Save" option
-        menu_win.chgat(max_index + 4, (width - len(save_option)) // 2, len(save_option), get_color("settings_save"))
+        menu_win.chgat(menu_win.getmaxyx()[0] - 2, (width - len(save_option)) // 2, len(save_option), get_color("settings_save"))
     else:
-        menu_win.chgat(old_idx + 3, 4, width - 8, get_color("settings_sensitive") if options[old_idx] in sensitive_settings else get_color("settings_default"))
+        menu_pad.chgat(old_idx, 0, menu_pad.getmaxyx()[1], get_color("settings_sensitive") if options[old_idx] in sensitive_settings else get_color("settings_default"))
 
     if show_save_option and new_idx == max_index: # special case highlight "Save" option
-        menu_win.chgat(max_index + 4, (width - len(save_option)) // 2, len(save_option), get_color("settings_save", reverse = True))
+        menu_win.chgat(menu_win.getmaxyx()[0] - 2, (width - len(save_option)) // 2, len(save_option), get_color("settings_save", reverse = True))
     else:
-       menu_win.chgat(new_idx + 3, 4, width - 8, get_color("settings_sensitive", reverse=True) if options[new_idx] in sensitive_settings else get_color("settings_default", reverse = True))
+       menu_pad.chgat(new_idx, 0,menu_pad.getmaxyx()[1], get_color("settings_sensitive", reverse=True) if options[new_idx] in sensitive_settings else get_color("settings_default", reverse = True))
 
     menu_win.refresh()
+
+    start_index = max(0, new_idx - (menu_win.getmaxyx()[0] - 5 - (2 if show_save_option else 0)) - (1 if show_save_option and new_idx == max_index else 0))  # Leave room for borders
+    menu_pad.refresh(start_index, 0,
+                     menu_win.getbegyx()[0] + 3, menu_win.getbegyx()[1] + 4,
+                     menu_win.getbegyx()[0] + 3 + menu_win.getmaxyx()[0] - 5 - (2 if show_save_option else 0), menu_win.getbegyx()[1] + menu_win.getmaxyx()[1] - 8)
 
 def settings_menu(stdscr, interface):
 


### PR DESCRIPTION
Fixes crash in settings when the window height is too small to accommodate the full list of options.

The math on this is really gross sorry. 

Fixes #63. 