### PR TITLE
Fix crash in get node details

### DIFF
--- a/ui/curses_ui.py
+++ b/ui/curses_ui.py
@@ -34,7 +34,7 @@ def draw_node_details():
                            if 'user' in node and 'shortName' in node['user'] else "",
                          f" | {node['user']['hwModel']}"
                            if 'user' in node and 'hwModel' in node['user'] else "",
-                         f" | {get_time_ago(node['lastHeard'])}" if 'lastHeard' in node else "",
+                         f" | {get_time_ago(node['lastHeard'])}" if ('lastHeard' in node and node['lastHeard']) else "",
                          f" | Hops: {node['hopsAway']}" if 'hopsAway' in node else "",
                          f" | SNR: {node['snr']}dB"
                            if ('snr' in node and 'hopsAway' in node and node['hopsAway'] == 0)


### PR DESCRIPTION
The last heard timestamp apparently sometimes gets populated in the dict as None, instead of just not being present, which caused a crash. Check for None before tryint to use it.