### PR TITLE
Fix error "No module named 'ui.ui_state'"

### DIFF
--- a/contact/utilities/singleton.py
+++ b/contact/utilities/singleton.py
@@ -1,4 +1,4 @@
-from ui.ui_state import ChatUIState, InterfaceState, AppState
+from contact.ui.ui_state import ChatUIState, InterfaceState, AppState
 
 ui_state = ChatUIState()
 interface_state = InterfaceState()


### PR DESCRIPTION
Was unable to run locally at tips due to an import not including the package name.